### PR TITLE
#2 Added Join Fields to Where Query

### DIFF
--- a/src/statement.ts
+++ b/src/statement.ts
@@ -129,7 +129,10 @@ class BaseStatement<SchemaType> {
 /**
  * Holds some common query filters that are used with multiple different statement types.
  */
-class QueryStatement<SchemaType> extends BaseStatement<SchemaType> {
+class QueryStatement<
+    SchemaType,
+    JoinSchemas extends any[] = never[]
+> extends BaseStatement<SchemaType> {
     constructor(connection?: IDbConnection) {
         super(connection);
     }
@@ -139,7 +142,7 @@ class QueryStatement<SchemaType> extends BaseStatement<SchemaType> {
      * @param amount The limit amount.
      * @returns The full statement with the added limit.
      */
-    public limit(amount: number): QueryStatement<SchemaType> {
+    public limit(amount: number): QueryStatement<SchemaType, JoinSchemas> {
         this.append(`LIMIT ${amount}`);
         return this;
     }
@@ -151,9 +154,9 @@ class QueryStatement<SchemaType> extends BaseStatement<SchemaType> {
      * @returns The full statement with the added order by.
      */
     public orderBy(
-        column: keyof SchemaType,
+        column: keyof SchemaType | AnyKeyInArray<JoinSchemas>[number],
         order: Order = "ASC"
-    ): QueryStatement<SchemaType> {
+    ): QueryStatement<SchemaType, JoinSchemas> {
         this.append(`ORDER BY ${column} ${order}`);
         return this;
     }
@@ -166,20 +169,24 @@ class QueryStatement<SchemaType> extends BaseStatement<SchemaType> {
      * @returns The full statement with the added where.
      */
     public where(
-        field: keyof SchemaType,
+        field: keyof SchemaType | AnyKeyInArray<JoinSchemas>[number],
         operator: Extract<WhereOp, "IN">,
-        value: SchemaType[keyof SchemaType][]
-    ): QueryStatement<SchemaType>;
+        value:
+            | SchemaType[keyof SchemaType][]
+            | JoinSchemas[number][AnyKeyInArray<JoinSchemas>[number]][]
+    ): QueryStatement<SchemaType, JoinSchemas>;
     public where(
-        field: keyof SchemaType,
+        field: keyof SchemaType | AnyKeyInArray<JoinSchemas>[number],
         operator: Extract<WhereOp, "IS" | "IS NOT">,
         value: null
-    ): QueryStatement<SchemaType>;
+    ): QueryStatement<SchemaType, JoinSchemas>;
     public where(
-        field: keyof SchemaType,
+        field: keyof SchemaType | AnyKeyInArray<JoinSchemas>[number],
         operator: Exclude<WhereOp, "IN" | "IS" | "IS NOT">,
-        value: SchemaType[keyof SchemaType]
-    ): QueryStatement<SchemaType>;
+        value:
+            | SchemaType[keyof SchemaType]
+            | JoinSchemas[number][AnyKeyInArray<JoinSchemas>[number]]
+    ): QueryStatement<SchemaType, JoinSchemas>;
     /**
      * Adds a multiple condition where clause to the query.
      * @param aggregation An aggregation object with as many levels as necessary.
@@ -187,13 +194,17 @@ class QueryStatement<SchemaType> extends BaseStatement<SchemaType> {
      */
     public where(
         aggregation: WhereAggregation<SchemaType>
-    ): QueryStatement<SchemaType>;
+    ): QueryStatement<SchemaType, JoinSchemas>;
     public where(
-        agg: keyof SchemaType | WhereAggregation<SchemaType>,
+        agg:
+            | (keyof SchemaType | AnyKeyInArray<JoinSchemas>[number])
+            | WhereAggregation<SchemaType>,
         operator?: WhereOp,
         value?:
             | SchemaType[keyof SchemaType]
             | SchemaType[keyof SchemaType][]
+            | JoinSchemas[number][AnyKeyInArray<JoinSchemas>[number]]
+            | JoinSchemas[number][AnyKeyInArray<JoinSchemas>[number]][]
             | null
     ) {
         const [query, variables] =
@@ -292,7 +303,7 @@ class SelectStatement<
      * @returns The full statement with the group by applied.
      */
     groupBy(
-        column: keyof SchemaType
+        column: keyof SchemaType | AnyKeyInArray<JoinSchemas>[number]
     ): SelectStatement<SchemaType, JoinSchemas> {
         this.append(`GROUP BY ${column}`);
         return this;

--- a/tests/statement.test.ts
+++ b/tests/statement.test.ts
@@ -1,7 +1,13 @@
-import { IDbConnection } from '../src/connection';
-import { DeleteStatement, QueryStatement, SelectStatement, UpdateStatement, InsertStatement } from '../src/statement';
-import Table from '../src/table';
-import { Nullable } from '../src/utilities';
+import { IDbConnection } from "../src/connection";
+import {
+    DeleteStatement,
+    QueryStatement,
+    SelectStatement,
+    UpdateStatement,
+    InsertStatement,
+} from "../src/statement";
+import Table from "../src/table";
+import { Nullable } from "../src/utilities";
 
 interface TestTableSchema {
     tableId: number;
@@ -15,261 +21,313 @@ interface ForeignTableSchema {
     someColumn: string;
 }
 
-const TEST_TABLE: string = 'TEST_TABLE';
+const TEST_TABLE: string = "TEST_TABLE";
 
-const FOREIGN_TABLE: string = 'FOREIGN_TABLE';
+const FOREIGN_TABLE: string = "FOREIGN_TABLE";
 
 const TEST_RESULTS: TestTableSchema[] = [
     {
         tableId: 1,
-        description: 'description',
-        active: false
-    }
+        description: "description",
+        active: false,
+    },
 ];
 
 const MOCK_CONNECTION: IDbConnection = {
-    execute: jest.fn(async (x, y) => Promise.resolve([TEST_RESULTS, []]))
-}
+    execute: jest.fn(async (x, y) => Promise.resolve([TEST_RESULTS, []])),
+};
 
-describe('class QueryStatement', () => {
+describe("class QueryStatement", () => {
     let statement: QueryStatement<TestTableSchema>;
 
     beforeEach(() => {
         statement = new QueryStatement<TestTableSchema>();
     });
 
-    describe('method limit', () => {
-        it('should apply a limit', () => {
+    describe("method limit", () => {
+        it("should apply a limit", () => {
             statement.limit(3);
             expect(statement.query).toEqual(`LIMIT 3`);
         });
     });
 
-    describe('method orderBy', () => {
-        it('should order by the default value (asc)', () => {
-            statement.orderBy('tableId');
+    describe("method orderBy", () => {
+        it("should order by the default value (asc)", () => {
+            statement.orderBy("tableId");
             expect(statement.query).toEqual(`ORDER BY tableId ASC`);
         });
 
-        it('should order by desc', () => {
-            statement.orderBy('tableId', 'DESC');
+        it("should order by desc", () => {
+            statement.orderBy("tableId", "DESC");
             expect(statement.query).toEqual(`ORDER BY tableId DESC`);
         });
     });
 
-    describe('method where', () => {
-        test('with just one operation', () => {
-            statement.where('active', '=', true);
-            expect(statement.query).toEqual('WHERE active = ?');
+    describe("method where", () => {
+        test("with just one operation", () => {
+            statement.where("active", "=", true);
+            expect(statement.query).toEqual("WHERE active = ?");
             expect(statement.variables).toEqual([true]);
         });
 
-        test('with an AND operation', () => {
+        test("with an AND operation", () => {
             statement.where({
                 AND: [
                     {
-                        field: 'tableId',
-                        operator: '=',
-                        value: 1
+                        field: "tableId",
+                        operator: "=",
+                        value: 1,
                     },
                     {
-                        field: 'description',
-                        operator: '!=',
-                        value: 'done'
-                    }
-                ]
+                        field: "description",
+                        operator: "!=",
+                        value: "done",
+                    },
+                ],
             });
-            expect(statement.query).toEqual('WHERE (tableId = ? AND description != ?)');
-            expect(statement.variables).toEqual([1, 'done']);
+            expect(statement.query).toEqual(
+                "WHERE (tableId = ? AND description != ?)"
+            );
+            expect(statement.variables).toEqual([1, "done"]);
         });
 
-        test('with an OR operation', () => {
+        test("with an OR operation", () => {
             statement.where({
                 OR: [
                     {
-                        field: 'tableId',
-                        operator: '>',
-                        value: 5
+                        field: "tableId",
+                        operator: ">",
+                        value: 5,
                     },
                     {
-                        field: 'description',
-                        operator: 'IS',
-                        value: null
-                    }
-                ]
+                        field: "description",
+                        operator: "IS",
+                        value: null,
+                    },
+                ],
             });
-            expect(statement.query).toEqual('WHERE (tableId > ? OR description IS ?)');
+            expect(statement.query).toEqual(
+                "WHERE (tableId > ? OR description IS ?)"
+            );
             expect(statement.variables).toEqual([5, null]);
         });
 
-        test('with a nested aggregation', () => {
+        test("with a nested aggregation", () => {
             statement.where({
                 AND: [
                     {
                         OR: [
                             {
-                                field: 'tableId',
-                                operator: 'IN',
-                                value: [1]
+                                field: "tableId",
+                                operator: "IN",
+                                value: [1],
                             },
                             {
-                                field: 'description',
-                                operator: 'IS NOT',
-                                value: null
-                            }
-                        ]
+                                field: "description",
+                                operator: "IS NOT",
+                                value: null,
+                            },
+                        ],
                     },
                     {
-                        field: 'active',
-                        operator: '!=',
-                        value: false
-                    }
-                ]
+                        field: "active",
+                        operator: "!=",
+                        value: false,
+                    },
+                ],
             });
-            expect(statement.query).toEqual('WHERE ((tableId IN ? OR description IS NOT ?) AND active != ?)');
+            expect(statement.query).toEqual(
+                "WHERE ((tableId IN ? OR description IS NOT ?) AND active != ?)"
+            );
             expect(statement.variables).toEqual([[1], null, false]);
         });
     });
 
-    describe('method exec', () => {
-        describe('when given no connection', () => {
-            it('should throw an error', () => {
-                expect(statement.exec()).rejects.toThrow('Database not connected');
+    describe("method exec", () => {
+        describe("when given no connection", () => {
+            it("should throw an error", () => {
+                expect(statement.exec()).rejects.toThrow(
+                    "Database not connected"
+                );
             });
         });
 
-        describe('when given a connection', () => {
+        describe("when given a connection", () => {
             beforeEach(() => {
-                statement = new QueryStatement<TestTableSchema>(MOCK_CONNECTION);
+                statement = new QueryStatement<TestTableSchema>(
+                    MOCK_CONNECTION
+                );
             });
 
-            it('should return results', () => {
+            it("should return results", () => {
                 expect(statement.exec()).resolves.toEqual(TEST_RESULTS);
-            })
+            });
         });
     });
 });
 
-describe('class SelectStatement', () => {
+describe("class SelectStatement", () => {
     const BASE_STATMENT = `SELECT tableId FROM ${TEST_TABLE}`;
     let statement: SelectStatement<TestTableSchema>;
 
     beforeEach(() => {
-        statement = new SelectStatement<TestTableSchema>(TEST_TABLE, ['tableId']);
+        statement = new SelectStatement<TestTableSchema>(TEST_TABLE, [
+            "tableId",
+        ]);
     });
-    
-    describe('constructor', () => {
-        describe('when given only a table name', () => {
+
+    describe("constructor", () => {
+        describe("when given only a table name", () => {
             beforeEach(() => {
                 statement = new SelectStatement<TestTableSchema>(TEST_TABLE);
             });
 
-            it('should select all the fields', () => {
+            it("should select all the fields", () => {
                 expect(statement.query).toEqual(`SELECT * FROM ${TEST_TABLE}`);
             });
-        })
+        });
 
-        it('should select the given fields', () => {
+        it("should select the given fields", () => {
             expect(statement.query).toEqual(BASE_STATMENT);
         });
     });
 
-    describe('method innerJoin', () => {
-        let joinStatement: SelectStatement<TestTableSchema, [ForeignTableSchema]>;
+    describe("method innerJoin", () => {
+        let joinStatement: SelectStatement<
+            TestTableSchema,
+            [ForeignTableSchema]
+        >;
         let foreignTable: Table<ForeignTableSchema>;
 
         beforeEach(() => {
-            joinStatement = new SelectStatement<TestTableSchema, [ForeignTableSchema]>(TEST_TABLE, ['tableId'])
+            joinStatement = new SelectStatement<
+                TestTableSchema,
+                [ForeignTableSchema]
+            >(TEST_TABLE, ["tableId"]);
             foreignTable = new Table<ForeignTableSchema>(FOREIGN_TABLE);
         });
 
-        it('should join on the given table/fields', () => {
-            joinStatement.innerJoin(foreignTable, 'tableId', 'tableId');
-            expect(joinStatement.query).toEqual(`${BASE_STATMENT} INNER JOIN FOREIGN_TABLE ON tableId = tableId`);
+        it("should join on the given table/fields", () => {
+            joinStatement.innerJoin(foreignTable, "tableId", "tableId");
+            expect(joinStatement.query).toEqual(
+                `${BASE_STATMENT} INNER JOIN FOREIGN_TABLE ON tableId = tableId`
+            );
+        });
+
+        it("should be able to use join fields in additional methods", () => {
+            joinStatement
+                .innerJoin(foreignTable, "tableId", "tableId")
+                .groupBy("foreignId")
+                .where("foreignId", "=", 1)
+                .orderBy("foreignId");
+            expect(joinStatement.query).toEqual(
+                `${BASE_STATMENT} INNER JOIN FOREIGN_TABLE ON tableId = tableId GROUP BY foreignId WHERE foreignId = ? ORDER BY foreignId ASC`
+            );
         });
     });
-    
-    describe('method groupBy', () => {
-        it('should group by the field', () => {
-            statement.groupBy('active');
+
+    describe("method groupBy", () => {
+        it("should group by the field", () => {
+            statement.groupBy("active");
             expect(statement.query).toEqual(`${BASE_STATMENT} GROUP BY active`);
         });
     });
 });
 
-describe('class UpdateStatement', () => {
+describe("class UpdateStatement", () => {
     const BASE_STATMENT = `UPDATE ${TEST_TABLE}`;
     let statement: UpdateStatement<TestTableSchema>;
 
-    describe('constructor', () => {
-        describe('with a single update', () => {
+    describe("constructor", () => {
+        describe("with a single update", () => {
             beforeEach(() => {
-                statement = new UpdateStatement<TestTableSchema>(TEST_TABLE, {field: 'active', value: false});
+                statement = new UpdateStatement<TestTableSchema>(TEST_TABLE, {
+                    field: "active",
+                    value: false,
+                });
             });
-    
-            it('should format the update', () => {
-                expect(statement.query).toEqual(`${BASE_STATMENT} SET active = ?`);
+
+            it("should format the update", () => {
+                expect(statement.query).toEqual(
+                    `${BASE_STATMENT} SET active = ?`
+                );
                 expect(statement.variables).toEqual([false]);
             });
         });
-    
-        describe('with multiple updates', () => {
+
+        describe("with multiple updates", () => {
             beforeEach(() => {
                 statement = new UpdateStatement<TestTableSchema>(TEST_TABLE, [
-                    {field: 'description', value: null},
-                    {field: 'active', value: false}
+                    { field: "description", value: null },
+                    { field: "active", value: false },
                 ]);
             });
-    
-            it('should format the update', () => {
-                expect(statement.query).toEqual(`${BASE_STATMENT} SET description = ?, active = ?`);
+
+            it("should format the update", () => {
+                expect(statement.query).toEqual(
+                    `${BASE_STATMENT} SET description = ?, active = ?`
+                );
                 expect(statement.variables).toEqual([null, false]);
             });
         });
     });
 });
 
-describe('class DeleteStatement', () => {
+describe("class DeleteStatement", () => {
     let statement: DeleteStatement<TestTableSchema>;
 
-    describe('constructor', () => {
+    describe("constructor", () => {
         beforeEach(() => {
             statement = new DeleteStatement<TestTableSchema>(TEST_TABLE);
         });
 
-        it('should format the delete', () => {
+        it("should format the delete", () => {
             expect(statement.query).toEqual(`DELETE FROM ${TEST_TABLE}`);
         });
     });
 });
 
-describe('class InsertStatement', () => {
+describe("class InsertStatement", () => {
     const BASE_STATMENT = `INSERT INTO ${TEST_TABLE}`;
     let statement: InsertStatement<TestTableSchema>;
 
-    describe('constructor', () => {
-        describe('with a single value', () => {
+    describe("constructor", () => {
+        describe("with a single value", () => {
             beforeEach(() => {
-                statement = new InsertStatement<TestTableSchema, 'tableId'>(TEST_TABLE, {active: false, description: 'something'});
+                statement = new InsertStatement<TestTableSchema, "tableId">(
+                    TEST_TABLE,
+                    { active: false, description: "something" }
+                );
             });
-    
-            it('should format the update', () => {
-                expect(statement.query).toEqual(`${BASE_STATMENT} (active, description) VALUES (?, ?)`);
-                expect(statement.variables).toEqual([false, 'something']);
+
+            it("should format the update", () => {
+                expect(statement.query).toEqual(
+                    `${BASE_STATMENT} (active, description) VALUES (?, ?)`
+                );
+                expect(statement.variables).toEqual([false, "something"]);
             });
         });
-    
-        describe('with multiple values', () => {
+
+        describe("with multiple values", () => {
             beforeEach(() => {
                 statement = new InsertStatement<TestTableSchema>(TEST_TABLE, [
-                    {tableId: 1, active: false, description: 'something'},
-                    {tableId: 2, active: true, description: null}
+                    { tableId: 1, active: false, description: "something" },
+                    { tableId: 2, active: true, description: null },
                 ]);
             });
-    
-            it('should format the update', () => {
-                expect(statement.query).toEqual(`${BASE_STATMENT} (tableId, active, description) VALUES (?, ?, ?), (?, ?, ?)`);
-                expect(statement.variables).toEqual([1, false, 'something', 2, true, null]);
+
+            it("should format the update", () => {
+                expect(statement.query).toEqual(
+                    `${BASE_STATMENT} (tableId, active, description) VALUES (?, ?, ?), (?, ?, ?)`
+                );
+                expect(statement.variables).toEqual([
+                    1,
+                    false,
+                    "something",
+                    2,
+                    true,
+                    null,
+                ]);
             });
         });
     });


### PR DESCRIPTION
### GitHub Issue
#2 

### Description
Added the join schemas from the SelectStatement to be passed down so you can use them on any of the chained calls (i.e. where, groupBy, orderBy)

### Testing
- [X] You can use the join fields in a where clause
- [X] You can use the join fields in a groupBy clause
- [X] You can use the join fields in an orderBy clause