### PR TITLE
#2 New Fix for Join Schemas in Where Queries

### DIFF
--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -12,6 +12,13 @@ export type NonEmptyArray<T> = [T, ...T[]];
 // A single value or array of values
 export type OptionalMulti<T> = T | NonEmptyArray<T>;
 
+// Source: https://stackoverflow.com/a/58310689
+export type UnionToIntersection<U> = (
+    U extends any ? (k: U) => void : never
+) extends (k: infer I) => void
+    ? I
+    : never;
+
 /**
  * Makes sure an optional multi is always an array.
  * @param value The value, single value or array of values.


### PR DESCRIPTION
**Issue:** #2 

Instead of passing the JoinSchemas array to the QueryStatement I've decided to combine the JoinSchemas and Schema into one type so it doesn't have to be specified everywhere to be used in the QueryStatement. This seems to keep the intellisense functionality I want as well (it was broken the old way).