### PR TITLE
#18 Insert/Update meta info

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "scripts": {
         "build": "tsc",
         "test": "jest",
+        "test-app": "ts-node tests/test-app.ts",
         "test-watch": "jest --watch",
         "test-watch-all": "jest --watchAll",
         "prepare": "tsc"

--- a/src/table.ts
+++ b/src/table.ts
@@ -69,7 +69,7 @@ class Table<SchemaType, PrimaryKey extends keyof SchemaType = never> {
      * @param updates The updates to make.
      * @returns The base update statement.
      */
-    update(updates: OptionalMulti<SetClause<SchemaType>>) {
+    update(updates: OptionalMulti<SetClause<SchemaType, PrimaryKey>>) {
         return new UpdateStatement<SchemaType>(
             this._name,
             updates,

--- a/tests/test-app.ts
+++ b/tests/test-app.ts
@@ -1,0 +1,87 @@
+import musqrat from "../src/index";
+
+// Set up:
+// 1. Add new user to MySQL "musqrattestuser"
+// 2. Add new database "musqrattest"
+// 3. Add new table "TestTable"
+/*
+CREATE TABLE TestTable
+(
+    Test_Id INT NOT NULL AUTO_INCREMENT,
+    Description VARCHAR(64) NOT NULL,
+    Deactivated DATETIME DEFAULT NULL,
+    PRIMARY KEY (Test_Id)
+);
+*/
+
+const TEST_ENV = {
+  USER: "musqrattestuser",
+  PASSWORD: "musqrattestpassword",
+  HOST: "localhost",
+  DATABASE: "musqrattest",
+  TABLE: "TestTable",
+};
+
+interface ITestTable {
+  Test_Id: number;
+  Description: string;
+  Deactivated?: Date;
+}
+
+async function main() {
+  console.log("musqrat test app");
+  try {
+    musqrat.connect({
+      user: TEST_ENV.USER,
+      password: TEST_ENV.PASSWORD,
+      host: TEST_ENV.HOST,
+      database: TEST_ENV.DATABASE,
+    });
+  } catch (err) {
+    console.error("Error connecting to the database", "main");
+    console.error(err.message);
+    return;
+  }
+
+  const Table = musqrat.initTable<ITestTable, "Test_Id">(TEST_ENV.TABLE);
+
+  // Insert
+  let result: any = await Table.insert([
+    { Description: "first test" },
+    { Description: "second test" },
+  ]).exec();
+  console.log("\nInsert result:");
+  console.log(JSON.stringify(result));
+
+  // Select
+  result = await Table.select("Test_Id", "Description", "Deactivated").exec();
+  console.log("\nSelect result:");
+  console.log(JSON.stringify(result));
+
+  // Update
+  result = await Table.update({
+    field: "Description",
+    value: "Final Value",
+  }).exec();
+  console.log("Update result:");
+  console.log(JSON.stringify(result));
+
+  // Select
+  result = await Table.select("Test_Id", "Description", "Deactivated").exec();
+  console.log("\nSelect result:");
+  console.log(JSON.stringify(result));
+
+  // Delete
+  result = await Table.delete().exec();
+  console.log("Delete result:");
+  console.log(JSON.stringify(result));
+
+  // Select
+  result = await Table.select("Test_Id", "Description", "Deactivated").exec();
+  console.log("\nSelect result:");
+  console.log(JSON.stringify(result));
+
+  return;
+}
+
+main();


### PR DESCRIPTION
#18 

- Changed the types when performing an insert/update/delete because mysql does not support returning the actual rows.
- Added a live test script so changes can be tested on a real database as well

- [X] All tests pass
- [X] Test script works