### PR TITLE
v0.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "musqrat",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "musqrat",
-    "version": "0.3.0",
+    "version": "0.3.1",
     "description": "A lightweight, strongly typed wrapper for using MySQL in Node.js",
     "main": "./dist/index.js",
     "types": "./dist/index.d.ts",

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -144,7 +144,7 @@ export const mockUpdate = <
 >(
   table: Table<SchemaType, PrimaryKey>,
   updates: OptionalMulti<SetClause<SchemaType, PrimaryKey>>,
-  values: OptionalEmptyMulti<SchemaType>,
+  values: OptionalEmptyMulti<Partial<SchemaType>>,
   error?: string
 ): jest.SpyInstance<UpdateStatement<SchemaType>> => {
   return jest


### PR DESCRIPTION
Changed return type in mockUpdate because it is likely not the whole
 object being updated/returned from code.